### PR TITLE
Adds option to save on focus out

### DIFF
--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -29,6 +29,7 @@ export default Component.extend({
 
   showSaveButton: true,
   showCancelButton: true,
+  saveOnFocusOut: false,
 
   editorClass: '',
   buttonContainerClass: '',
@@ -64,7 +65,11 @@ export default Component.extend({
       if (this.onOutsideClick) {
         this.onOutsideClick(this.value) && set(this, 'isEditing', false)
       } else {
-        this.send('cancel')
+        if(this.saveOnFocusOut) {
+          this.send('save')
+        } else {
+          this.send('cancel')
+        }
       }
     }
   },


### PR DESCRIPTION
Adds the ability to make the component save on focus out. This in turned off by default but can be turned on by setting the value saveOnFocusOut to true.

for example:
```
{{ember-inline-edit
  value=(readonly value)
  onSave=(action 'onSave')
  saveOnFocusOut=true
}}
```
